### PR TITLE
Implement roleNames, remove call to setRoleNames

### DIFF
--- a/src/movielistmodel.cpp
+++ b/src/movielistmodel.cpp
@@ -25,14 +25,12 @@
 MovieListModel::MovieListModel(QObject* parent) :
     QAbstractListModel(parent)
 {
-    QHash<int, QByteArray> roles;
-    roles[MovieIdRole] = "id";
-    roles[MovieImdbIdRole] = "imdbId";
-    roles[MovieNameRole] = "name";
-    roles[MovieInfoRole] = "info";
-    roles[MovieTimesRole] = "showtimes";
-    roles[MovieDescriptionRole] = "description";
-    setRoleNames(roles);
+    m_roles[MovieIdRole] = "id";
+    m_roles[MovieImdbIdRole] = "imdbId";
+    m_roles[MovieNameRole] = "name";
+    m_roles[MovieInfoRole] = "info";
+    m_roles[MovieTimesRole] = "showtimes";
+    m_roles[MovieDescriptionRole] = "description";
 }
 
 MovieListModel::~MovieListModel()
@@ -70,6 +68,11 @@ int MovieListModel::rowCount(const QModelIndex& index) const
 {
     Q_UNUSED(index)
     return m_movies.count();
+}
+
+QHash<int, QByteArray> MovieListModel::roleNames() const
+{
+    return m_roles;
 }
 
 QVariantMap MovieListModel::get(const QModelIndex& index) const

--- a/src/movielistmodel.h
+++ b/src/movielistmodel.h
@@ -59,6 +59,9 @@ public:
     //! \reimp
     int rowCount(const QModelIndex& index = QModelIndex()) const;
 
+    //! \reimp
+    QHash<int, QByteArray> roleNames() const;
+
     //! Convenience method which provides a QVariantMap for the movie
     //! at the given index
     //!
@@ -77,6 +80,7 @@ signals:
 private:
     Q_DISABLE_COPY(MovieListModel)
     QList<Movie> m_movies;
+    QHash<int, QByteArray> m_roles;
 };
 
 #endif // MOVIELISTMODEL_H

--- a/src/theaterlistmodel.cpp
+++ b/src/theaterlistmodel.cpp
@@ -28,11 +28,9 @@ TheaterListModel::TheaterListModel(QObject* parent)
       m_cinemas(),
       m_currentMovieListModel(0)
 {
-    QHash<int, QByteArray> roles;
-    roles[TheaterNameRole] = "name";
-    roles[TheaterInfoRole] = "info";
-    roles[TheaterMovieListRole] = "playing";
-    setRoleNames(roles);
+    m_roles[TheaterNameRole] = "name";
+    m_roles[TheaterInfoRole] = "info";
+    m_roles[TheaterMovieListRole] = "playing";
 }
 
 TheaterListModel::~TheaterListModel()
@@ -44,6 +42,11 @@ int TheaterListModel::rowCount(const QModelIndex& index) const
 {
     Q_UNUSED(index)
     return m_cinemas.count();
+}
+
+QHash<int, QByteArray> TheaterListModel::roleNames() const
+{
+    return m_roles;
 }
 
 QVariant TheaterListModel::data(const QModelIndex& index, int role) const

--- a/src/theaterlistmodel.h
+++ b/src/theaterlistmodel.h
@@ -56,6 +56,9 @@ public:
     //! \reimp
     int rowCount(const QModelIndex& index = QModelIndex()) const;
 
+    //! \reimp
+    QHash<int, QByteArray> roleNames() const;
+
     //! Sets a cinema list to the model
     //! \param cinemas The list of cinemas to set to the model
     void setCinemaList(QList<Cinema> cinemas);
@@ -81,6 +84,7 @@ private:
     Q_DISABLE_COPY(TheaterListModel)
     QList<Cinema> m_cinemas;
     MovieListModel* m_currentMovieListModel;
+    QHash<int, QByteArray> m_roles;
 };
 
 #endif // THEATERLISTMODEL_H


### PR DESCRIPTION
as setRoleNames is deprecated in Qt5.

This commit does not change functionality but helps to keep the same
codebase for Qt4 and Qt5
