### PR TITLE
Change list models

### DIFF
--- a/src/movielistmodel.cpp
+++ b/src/movielistmodel.cpp
@@ -31,6 +31,9 @@ MovieListModel::MovieListModel(QObject* parent) :
     m_roles[MovieInfoRole] = "info";
     m_roles[MovieTimesRole] = "showtimes";
     m_roles[MovieDescriptionRole] = "description";
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+    setRoleNames(m_roles);
+    #endif
 }
 
 MovieListModel::~MovieListModel()
@@ -70,10 +73,12 @@ int MovieListModel::rowCount(const QModelIndex& index) const
     return m_movies.count();
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 QHash<int, QByteArray> MovieListModel::roleNames() const
 {
     return m_roles;
 }
+#endif
 
 QVariantMap MovieListModel::get(const QModelIndex& index) const
 {

--- a/src/movielistmodel.h
+++ b/src/movielistmodel.h
@@ -59,8 +59,10 @@ public:
     //! \reimp
     int rowCount(const QModelIndex& index = QModelIndex()) const;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
     //! \reimp
     QHash<int, QByteArray> roleNames() const;
+#endif
 
     //! Convenience method which provides a QVariantMap for the movie
     //! at the given index

--- a/src/theaterlistmodel.cpp
+++ b/src/theaterlistmodel.cpp
@@ -31,6 +31,9 @@ TheaterListModel::TheaterListModel(QObject* parent)
     m_roles[TheaterNameRole] = "name";
     m_roles[TheaterInfoRole] = "info";
     m_roles[TheaterMovieListRole] = "playing";
+    #if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
+    setRoleNames(m_roles);
+    #endif
 }
 
 TheaterListModel::~TheaterListModel()
@@ -44,10 +47,12 @@ int TheaterListModel::rowCount(const QModelIndex& index) const
     return m_cinemas.count();
 }
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 QHash<int, QByteArray> TheaterListModel::roleNames() const
 {
     return m_roles;
 }
+#endif
 
 QVariant TheaterListModel::data(const QModelIndex& index, int role) const
 {

--- a/src/theaterlistmodel.h
+++ b/src/theaterlistmodel.h
@@ -56,8 +56,10 @@ public:
     //! \reimp
     int rowCount(const QModelIndex& index = QModelIndex()) const;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
     //! \reimp
     QHash<int, QByteArray> roleNames() const;
+#endif
 
     //! Sets a cinema list to the model
     //! \param cinemas The list of cinemas to set to the model


### PR DESCRIPTION
Proper fix for previous pull #28

In Qt4 roleNames() is not virtual thus we have to call setRoleNames()
