### PR TITLE
Adapt TheaterShowtimesFetcher to work with Sailfish

### DIFF
--- a/src/theatershowtimesfetcher.h
+++ b/src/theatershowtimesfetcher.h
@@ -22,10 +22,13 @@
 
 #include <QObject>
 #include <QUrl>
+#if (QT_VERSION >= QT_VERSION_CHECK(5,0,0))
+#   include <QUrlQuery>
+#endif
 #include "movie.h"
 #include "cinema.h"
 
-class QWebView;
+class QWebPage;
 class TheaterListModel;
 
 //! \class TheaterShowtimesFetcher
@@ -61,9 +64,14 @@ private slots:
     void onLoadFinished(bool ok);
 
 private:
-    QWebView *m_webView;
+    QWebPage *m_webPage;
     TheaterListModel *m_theaterListModel;
     QUrl m_showtimesBaseUrl;
+#if (QT_VERSION < QT_VERSION_CHECK(5,0,0))
+    QUrl m_showtimesQuery;
+#else
+    QUrlQuery m_showtimesQuery;
+#endif
     int m_numPages;
     int m_parsedPages;
     QList<Cinema> m_cinemas;


### PR DESCRIPTION
-Use QWebPage instead of QWebView as we don't really need the view and
in Sailfish we don't have a widget.
-Use QUrlQuery for Qt5
-For Jolla Store we would something which completely does not rely on QtWidgets (i.e. QWebPage et al)
-Tested on Harmattan device and still works
